### PR TITLE
fix: check if Hetzner returned error in body

### DIFF
--- a/src/Hetzner/Robot/Client.php
+++ b/src/Hetzner/Robot/Client.php
@@ -80,7 +80,11 @@ class Client extends RestClient
 
     if ($result['response_code'] >= 400 && $result['response_code'] <= 503)
     {
-      throw new ClientException($response->error->message, $response->error->code);
+      if (isset($response->error) && isset($response->error->message, $response->error->code)) {
+        throw new ClientException($response->error->message, $response->error->code);
+      } else {
+        throw new ClientException(null, $result['response_code']);
+      }
     }
 
     return $response;


### PR DESCRIPTION
In some cases (e.g. 404), Hetzner does not return an error in the body. This results in an undefined $response->error exception. I have added appropriate logic to make sure that if the error is missing from the body, this will properly  return the HTTP error code instead.